### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/linter-cppcheck.js
+++ b/lib/linter-cppcheck.js
@@ -27,7 +27,7 @@ from 'atom-linter';
 
 export default {
 
-  activate: (state) => {},
+  activate(state) {},
 
   config: {
     enableInformation: {
@@ -96,7 +96,7 @@ export default {
     },
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const regex =
             '\\[(?<file>.+?):(?:(?<line>\\d+)\\]|(?<lineStart>\\d+)\\]' +
             ' -> \\[.+?:(?<lineEnd>\\d+)\\]): ' +
@@ -216,6 +216,6 @@ export default {
     return provider;
   },
 
-  serialize: () => {},
+  serialize() {},
 
 };


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.