### PR TITLE
Add --suppressions-list and include path options

### DIFF
--- a/lib/linter-cppcheck.js
+++ b/lib/linter-cppcheck.js
@@ -85,10 +85,24 @@ export default {
       description: 'Enable inline suppressions.  (`--inline-suppr`)',
       type: 'boolean',
     },
+    suppressionsList: {
+      default: '',
+      description: 'Path to file containing the list of suppressed errors.',
+      type: 'string',
+    },
     suppress: {
       default: [],
       description: 'Suppress specific warnings. See Cppcheck\'s ' +
         'documentation for details on the format. (`--suppress`)',
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    include: {
+      default: [],
+      description: 'Give path to search for include files. See Cppcheck\'s ' +
+        'documentation for details on the format. (`-I`)',
       type: 'array',
       items: {
         type: 'string',
@@ -158,9 +172,20 @@ export default {
           break;
       }
 
+      // --suppressions-list
+      var list = atom.config.get('linter-cppcheck.suppressionsList')
+      if (list) {
+        args.push(`--suppressions-list=${list}`);
+      }
+
       // --suppress
       for (var suppress of atom.config.get('linter-cppcheck.suppress') || []) {
         args.push(`--suppress=${suppress}`);
+      }
+
+      // -I
+      for (var path of atom.config.get('linter-cppcheck.include') || []) {
+        args.push(`-I${path}`);
       }
 
       // <file>


### PR DESCRIPTION
Instead of listing all the suppressed errors one by one it would be very handful to add an option to use the --suppressions-list argument to pass a file containing the errors.

Then, for projects where the include files are not located in the same folder as the source files it helps being able to specify additional include paths.